### PR TITLE
arm: Fix `Patcher().search_xref()`

### DIFF
--- a/eyepatch/arm.py
+++ b/eyepatch/arm.py
@@ -221,9 +221,9 @@ class Patcher(eyepatch.base._Patcher):
                 insn_offset = (insn.offset & ~3) + op.mem.disp + 0x4
 
                 data = self.data[insn_offset : insn_offset + 4]
-                offset2 = unpack('<i', data)[0]
+                offset2 = unpack('<I', data)[0]
 
-                if offset2 - offset == base_addr:
+                if offset2 - base_addr == offset:
                     if skip == 0:
                         return insn
 


### PR DESCRIPTION
Using a signed int can overflow `data` into becoming a negative number.
Changed `data` to an unsigned 32-bit int.
Also subtraction was using the wrong value, fixed that too. Now xref works as expected.